### PR TITLE
Hide the dock icon

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -65,6 +65,11 @@ app.on('window-all-closed', function () {
     app.quit();
 });
 
+//on OSx a dock icon is shown, since this is a tray application, hide the dock icon.
+if (app.dock) {
+    app.dock.hide();
+}
+
 function overlayChanged({label}, window, event) {
 
     // Stop here if it is already selected...


### PR DESCRIPTION
On OSx an Electron dock icon is shown. This PR removes it.

On Windows/Linux the .dock property of the app is undefined so this only affects OSx
